### PR TITLE
Use selinux-utils role for managing selinux setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,29 +1,14 @@
----
+sudo: required
 language: python
-python: "2.7"
 
-# Use the new container infrastructure
-sudo: false
-
-# Install ansible
-addons:
-  apt:
-    packages:
-    - python-pip
+services:
+  - docker
 
 install:
-  # Install ansible
-  - pip install ansible
-
-  # Check ansible version
-  - ansible --version
-
-  # Create ansible.cfg with correct roles_path
-  - printf '[defaults]\nroles_path=../' >ansible.cfg
+  - pip install ansible docker-py molecule
 
 script:
-  # Basic role syntax check
-  - ansible-playbook tests/test.yml -i tests/inventory --syntax-check
+  - molecule test
 
 notifications:
   webhooks: https://galaxy.ansible.com/api/v1/notifications/

--- a/README.md
+++ b/README.md
@@ -8,11 +8,10 @@ Mostly Python modules.
 Dependencies
 ------------
 
-Depends on `basedeps`, `ice`, `omero-python-deps` and `selinux-utils`.
-Optionally depends on `redis`.
-
-By default `omero-python-deps` is installed with the default (recommended) options.
-If you wish you can set `omero_python_deps_recommended: False` to only install the minimum requirements.
+See `meta/main.yml`.
+The dependency `omero-python-deps` is installed with the default (recommended) options.
+If you wish you can set `omero_python_deps_recommended: False` to only install the minimum requirements, for instance during development.
+This is not supported in production.
 
 
 Role Variables

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Mostly Python modules.
 Dependencies
 ------------
 
-Depends on `basedeps`, `ice` and `omero-python-deps`.
+Depends on `basedeps`, `ice`, `omero-python-deps` and `selinux-utils`.
 Optionally depends on `redis`.
 
 By default `omero-python-deps` is installed with the default (recommended) options.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,4 +3,3 @@
 
 # Whether to install redis requirements
 omero_web_runtime_redis: False
-omero_selinux_setup: False

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -16,3 +16,4 @@ dependencies:
 - role: openmicroscopy.omero-python-deps
 - role: openmicroscopy.redis
   when: omero_web_runtime_redis
+- role: openmicroscopy.selinux-utils

--- a/molecule.yml
+++ b/molecule.yml
@@ -1,0 +1,29 @@
+---
+dependency:
+  name: galaxy
+  requirements_file: tests/requirements.yml
+
+driver:
+  name: docker
+
+vagrant:
+  platforms:
+    - name: centos7
+      box: centos/7
+  providers:
+    - name: virtualbox
+      type: virtualbox
+      options:
+        memory: 512
+        cpus: 1
+  instances:
+    - name: omero-web-runtime-vagrant
+
+docker:
+  containers:
+  - name: omero-web-runtime-docker
+    image: centos
+    image_version: 7
+
+verifier:
+  name: testinfra

--- a/playbook.yml
+++ b/playbook.yml
@@ -1,0 +1,4 @@
+---
+- hosts: all
+  roles:
+    - role: ansible-role-omero-web-runtime

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -35,18 +35,7 @@
     state: present
   when: omero_web_runtime_redis
 
-
 # selinux
-- name: omero | install selinux utilities
-  become: yes
-  yum:
-    name: "{{ item }}"
-    state: present
-  with_items:
-    - libselinux-python
-    - libsemanage-python
-    - policycoreutils-python
-  when: omero_selinux_setup
 
 - name: omero web | selinux booleans
   become: yes
@@ -57,7 +46,7 @@
   with_items:
     - httpd_read_user_content
     - httpd_enable_homedirs
-  when: omero_selinux_setup
+  when: selinux_enabled
 
 # Alternatively set httpd_can_network_connect=yes to allow all ports
 - name: omero web | selinux ports
@@ -67,4 +56,4 @@
     proto: tcp
     setype: http_port_t
     state: present
-  when: omero_selinux_setup
+  when: selinux_enabled

--- a/tests/inventory
+++ b/tests/inventory
@@ -1,1 +1,0 @@
-localhost

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -1,0 +1,5 @@
+- src: openmicroscopy.basedeps
+- src: openmicroscopy.ice
+- src: openmicroscopy.omero-python-deps
+- src: openmicroscopy.redis
+- src: openmicroscopy.selinux-utils

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,0 @@
----
-- hosts: localhost
-  remote_user: root
-  roles:
-  - role: ansible-role-omero-web-runtime

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -1,0 +1,23 @@
+import testinfra.utils.ansible_runner
+import pytest
+
+testinfra_hosts = testinfra.utils.ansible_runner.AnsibleRunner(
+    '.molecule/ansible_inventory').get_hosts('all')
+
+
+@pytest.mark.parametrize('name', ['Django', 'gunicorn'])
+def test_pip_packages(PipPackage, name):
+    assert name in PipPackage.get_packages()
+
+
+# These tests assume
+# - centos/7 Vagrantbox has selinux
+# - centos:7 docker image doesn't have selinux
+def test_selinux(Command, Sudo, TestinfraBackend):
+    host = TestinfraBackend.get_hostname()
+    if host == 'omero-web-runtime-docker':
+        assert not Command.exists('semanage')
+    else:
+        with Sudo():
+            out = Command.check_output('semanage port -l -C')
+            assert out.split()[-3:] == ['http_port_t', 'tcp', '4080']


### PR DESCRIPTION
Remove generic selinux tasks, use the `openmicroscopy.selinux-utils` role instead. Also adds a molecule test.

This means selinux should be handled automatically, the `omero_selinux_setup` variable has been removed.

Tag: probably 1.1.0 since this shouldn't break anything, chances are if you were to deliberately set `omero_selinux_setup` to something that doesn't match the current selinux status this role wouldn't work properly.